### PR TITLE
Fix bug on async db config

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -1,4 +1,5 @@
-from sqlalchemy import create_engine, Column, Integer, String, DateTime
+from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from dotenv import load_dotenv
@@ -8,8 +9,14 @@ from typing import Any
 load_dotenv()
 
 SQLALCHEMY_DATABASE_URL = os.getenv("DATABASE_URL")
-engine = create_engine(SQLALCHEMY_DATABASE_URL)
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+engine = create_async_engine(SQLALCHEMY_DATABASE_URL, echo=True)
+AsyncSessionLocal = sessionmaker(
+    bind=engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+    autoflush=False,
+    autocommit=False,
+)
 Base: Any = declarative_base()
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,26 +1,23 @@
 from fastapi import FastAPI, Depends
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 from app.services.tron_service import get_wallet_info
-from app.database import SessionLocal, WalletQuery
+from app.database import AsyncSessionLocal, WalletQuery
 from datetime import datetime
 from typing import Annotated
 
 app = FastAPI()
 
 
-def get_db():
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
+async def get_db() -> AsyncSession:
+    async with AsyncSessionLocal() as session:
+        yield session
 
 
 @app.post("/wallet-info")
-async def fetch_wallet_info(address: str, db: Annotated[Session, Depends(get_db)]):
+async def fetch_wallet_info(address: str, db: Annotated[AsyncSession, Depends(get_db)]):
     data = await get_wallet_info(address)
     current_time = datetime.now()
     db_query = WalletQuery(wallet_address=address, timestamp=current_time)
     db.add(db_query)
-    db.commit()
+    await db.commit()
     return data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 fastapi[standard]>=0.115.12
 uvicorn>=0.31.0
 sqlalchemy>=2.0.40
+sqlalchemy[asyncio]>=2.0.40
 pytest>=8.3.5
 alembic>=1.15.2
 aiohttp>=3.11.16


### PR DESCRIPTION
### Related issue

Closes #20

### List of changes

- Import using of `create_async_engine` and `AsyncSession` from `sqlalchemy.ext.asyncio`
- Replace `await db.commit()` with the correct asynchronous behavior.